### PR TITLE
Enable CUDA on ffmpeg 4.2

### DIFF
--- a/ffmpeg_dev/4.2/configure
+++ b/ffmpeg_dev/4.2/configure
@@ -6588,7 +6588,7 @@ if enabled x86; then
             disable ffnvcodec cuvid nvdec nvenc
             ;;
     esac
-elif enabled ppc64 && ! enabled bigendian; then
+elif enabled_any aarch64 ppc64 && ! enabled bigendian; then
     case $target_os in
         linux)
             ;;

--- a/ffmpeg_patches/ffmpeg4.2_nvmpi.patch
+++ b/ffmpeg_patches/ffmpeg4.2_nvmpi.patch
@@ -1,5 +1,5 @@
 diff --git a/configure b/configure
-index 16d9c78..3d0835c 100755
+index 5ee289f..8b47d51 100755
 --- a/configure
 +++ b/configure
 @@ -340,6 +340,7 @@ External library support:
@@ -87,6 +87,15 @@ index 16d9c78..3d0835c 100755
  
  
  if enabled gcrypt; then
+@@ -6575,7 +6588,7 @@ if enabled x86; then
+             disable ffnvcodec cuvid nvdec nvenc
+             ;;
+     esac
+-elif enabled ppc64 && ! enabled bigendian; then
++elif enabled_any aarch64 ppc64 && ! enabled bigendian; then
+     case $target_os in
+         linux)
+             ;;
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
 index 3cd73fb..c3ed5cc 100644
 --- a/libavcodec/Makefile


### PR DESCRIPTION
ffmpeg 4.2 disables ffnvcodec, cuvid, nvdec and nvenc on aarch64. While Jetson platforms don't support cuvid, they do support the cuda and npp filters, which depend on ffnvcodec and were thus unnecessarily disabled. Later versions of ffmpeg don't disable any of it on aarch64, so this simply backports the later behavior.