### PR TITLE
Add resize option to nvmpi decoder

### DIFF
--- a/ffmpeg_dev/4.2/configure
+++ b/ffmpeg_dev/4.2/configure
@@ -7410,7 +7410,7 @@ cat > $TMPH <<EOF
 #define FFMPEG_CONFIG_H
 #define FFMPEG_CONFIGURATION "$(c_escape $FFMPEG_CONFIGURATION)"
 #define FFMPEG_LICENSE "$(c_escape $license)"
-#define CONFIG_THIS_YEAR 2022
+#define CONFIG_THIS_YEAR 2023
 #define FFMPEG_DATADIR "$(eval c_escape $datadir)"
 #define AVCONV_DATADIR "$(eval c_escape $datadir)"
 #define CC_IDENT "$(c_escape ${cc_ident:-Unknown compiler})"

--- a/ffmpeg_dev/common/libavcodec/nvmpi_dec.c
+++ b/ffmpeg_dev/common/libavcodec/nvmpi_dec.c
@@ -70,6 +70,13 @@ static int nvmpi_init_decoder(AVCodecContext *avctx){
         return AVERROR(EINVAL);
     }
 	
+	//overwrite avctx w and h if resize option is used
+	if(resized.width && resized.height)
+	{
+		avctx->width = resized.width;
+		avctx->height = resized.height;
+	}
+
 	nvmpi_context->bufFrame = av_frame_alloc();
 	if (ff_get_buffer(avctx, nvmpi_context->bufFrame, 0) < 0) {
 		av_frame_free(&(nvmpi_context->bufFrame));

--- a/ffmpeg_patches/ffmpeg4.2_nvmpi.patch
+++ b/ffmpeg_patches/ffmpeg4.2_nvmpi.patch
@@ -1,5 +1,5 @@
 diff --git a/configure b/configure
-index 16d9c78..3d0835c 100755
+index 5ee289f..7722021 100755
 --- a/configure
 +++ b/configure
 @@ -340,6 +340,7 @@ External library support:
@@ -184,10 +184,10 @@ index d2f9a39..04dc62b 100644
  
 diff --git a/libavcodec/nvmpi_dec.c b/libavcodec/nvmpi_dec.c
 new file mode 100644
-index 0000000..4a77281
+index 0000000..166da0f
 --- /dev/null
 +++ b/libavcodec/nvmpi_dec.c
-@@ -0,0 +1,214 @@
+@@ -0,0 +1,221 @@
 +#include <stdio.h>
 +#include <stdlib.h>
 +#include <sys/time.h>
@@ -260,6 +260,13 @@ index 0000000..4a77281
 +        return AVERROR(EINVAL);
 +    }
 +	
++	//overwrite avctx w and h if resize option is used
++	if(resized.width && resized.height)
++	{
++		avctx->width = resized.width;
++		avctx->height = resized.height;
++	}
++
 +	nvmpi_context->bufFrame = av_frame_alloc();
 +	if (ff_get_buffer(avctx, nvmpi_context->bufFrame, 0) < 0) {
 +		av_frame_free(&(nvmpi_context->bufFrame));

--- a/ffmpeg_patches/ffmpeg4.2_nvmpi.patch
+++ b/ffmpeg_patches/ffmpeg4.2_nvmpi.patch
@@ -184,10 +184,10 @@ index d2f9a39..04dc62b 100644
  
 diff --git a/libavcodec/nvmpi_dec.c b/libavcodec/nvmpi_dec.c
 new file mode 100644
-index 0000000..25cea51
+index 0000000..4a77281
 --- /dev/null
 +++ b/libavcodec/nvmpi_dec.c
-@@ -0,0 +1,198 @@
+@@ -0,0 +1,214 @@
 +#include <stdio.h>
 +#include <stdlib.h>
 +#include <sys/time.h>
@@ -203,6 +203,7 @@ index 0000000..25cea51
 +#include "libavutil/hwcontext_drm.h"
 +#include "libavutil/imgutils.h"
 +#include "libavutil/log.h"
++#include "libavutil/opt.h"
 +
 +#if LIBAVCODEC_VERSION_MAJOR >= 60
 +#include "codec_internal.h"
@@ -214,6 +215,7 @@ index 0000000..25cea51
 +	nvmpictx* ctx;
 +	AVClass *av_class;
 +	AVFrame *bufFrame;
++	char *resize_expr;
 +} nvmpiDecodeContext;
 +
 +static nvCodingType nvmpi_get_codingtype(AVCodecContext *avctx)
@@ -234,6 +236,7 @@ index 0000000..25cea51
 +
 +	nvmpiDecodeContext *nvmpi_context = avctx->priv_data;
 +	nvCodingType codectype=NV_VIDEO_CodingUnused;
++	nvSize resized = {0};
 +	
 +	codectype =nvmpi_get_codingtype(avctx);
 +	if (codectype == NV_VIDEO_CodingUnused) {
@@ -250,6 +253,12 @@ index 0000000..25cea51
 +		av_log(avctx, AV_LOG_ERROR, "Invalid Pix_FMT for NVMPI: Only YUV420P and YUVJ420P are supported\n");
 +		return AVERROR_INVALIDDATA;
 +	}
++
++    if (nvmpi_context->resize_expr && sscanf(nvmpi_context->resize_expr, "%dx%d",
++                                             &resized.width, &resized.height) != 2) {
++        av_log(avctx, AV_LOG_ERROR, "Invalid resize expressions\n");
++        return AVERROR(EINVAL);
++    }
 +	
 +	nvmpi_context->bufFrame = av_frame_alloc();
 +	if (ff_get_buffer(avctx, nvmpi_context->bufFrame, 0) < 0) {
@@ -258,7 +267,7 @@ index 0000000..25cea51
 +		return AVERROR(ENOMEM);
 +	}
 +
-+	nvmpi_context->ctx=nvmpi_create_decoder(codectype,NV_PIX_YUV420);
++	nvmpi_context->ctx=nvmpi_create_decoder(codectype, NV_PIX_YUV420, resized);
 +
 +	if(!nvmpi_context->ctx){
 +		av_frame_free(&(nvmpi_context->bufFrame));
@@ -333,10 +342,17 @@ index 0000000..25cea51
 +
 +
 +
++#define OFFSET(x) offsetof(nvmpiDecodeContext, x)
++#define VD AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_DECODING_PARAM
++static const AVOption options[] = {
++    { "resize",   "Resize (width)x(height)", OFFSET(resize_expr), AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, VD },
++    { NULL }
++};
 +
 +#define NVMPI_DEC_CLASS(NAME) \
 +	static const AVClass nvmpi_##NAME##_dec_class = { \
 +		.class_name = "nvmpi_" #NAME "_dec", \
++		.option     = options, \
 +		.version    = LIBAVUTIL_VERSION_INT, \
 +	};
 +

--- a/ffmpeg_patches/ffmpeg4.4_nvmpi.patch
+++ b/ffmpeg_patches/ffmpeg4.4_nvmpi.patch
@@ -187,10 +187,10 @@ index 2e9a358..f75ebca 100644
  extern AVCodec ff_vp9_vaapi_encoder;
 diff --git a/libavcodec/nvmpi_dec.c b/libavcodec/nvmpi_dec.c
 new file mode 100644
-index 0000000..25cea51
+index 0000000..4a77281
 --- /dev/null
 +++ b/libavcodec/nvmpi_dec.c
-@@ -0,0 +1,198 @@
+@@ -0,0 +1,214 @@
 +#include <stdio.h>
 +#include <stdlib.h>
 +#include <sys/time.h>
@@ -206,6 +206,7 @@ index 0000000..25cea51
 +#include "libavutil/hwcontext_drm.h"
 +#include "libavutil/imgutils.h"
 +#include "libavutil/log.h"
++#include "libavutil/opt.h"
 +
 +#if LIBAVCODEC_VERSION_MAJOR >= 60
 +#include "codec_internal.h"
@@ -217,6 +218,7 @@ index 0000000..25cea51
 +	nvmpictx* ctx;
 +	AVClass *av_class;
 +	AVFrame *bufFrame;
++	char *resize_expr;
 +} nvmpiDecodeContext;
 +
 +static nvCodingType nvmpi_get_codingtype(AVCodecContext *avctx)
@@ -237,6 +239,7 @@ index 0000000..25cea51
 +
 +	nvmpiDecodeContext *nvmpi_context = avctx->priv_data;
 +	nvCodingType codectype=NV_VIDEO_CodingUnused;
++	nvSize resized = {0};
 +	
 +	codectype =nvmpi_get_codingtype(avctx);
 +	if (codectype == NV_VIDEO_CodingUnused) {
@@ -253,6 +256,12 @@ index 0000000..25cea51
 +		av_log(avctx, AV_LOG_ERROR, "Invalid Pix_FMT for NVMPI: Only YUV420P and YUVJ420P are supported\n");
 +		return AVERROR_INVALIDDATA;
 +	}
++
++    if (nvmpi_context->resize_expr && sscanf(nvmpi_context->resize_expr, "%dx%d",
++                                             &resized.width, &resized.height) != 2) {
++        av_log(avctx, AV_LOG_ERROR, "Invalid resize expressions\n");
++        return AVERROR(EINVAL);
++    }
 +	
 +	nvmpi_context->bufFrame = av_frame_alloc();
 +	if (ff_get_buffer(avctx, nvmpi_context->bufFrame, 0) < 0) {
@@ -261,7 +270,7 @@ index 0000000..25cea51
 +		return AVERROR(ENOMEM);
 +	}
 +
-+	nvmpi_context->ctx=nvmpi_create_decoder(codectype,NV_PIX_YUV420);
++	nvmpi_context->ctx=nvmpi_create_decoder(codectype, NV_PIX_YUV420, resized);
 +
 +	if(!nvmpi_context->ctx){
 +		av_frame_free(&(nvmpi_context->bufFrame));
@@ -336,10 +345,17 @@ index 0000000..25cea51
 +
 +
 +
++#define OFFSET(x) offsetof(nvmpiDecodeContext, x)
++#define VD AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_DECODING_PARAM
++static const AVOption options[] = {
++    { "resize",   "Resize (width)x(height)", OFFSET(resize_expr), AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, VD },
++    { NULL }
++};
 +
 +#define NVMPI_DEC_CLASS(NAME) \
 +	static const AVClass nvmpi_##NAME##_dec_class = { \
 +		.class_name = "nvmpi_" #NAME "_dec", \
++		.option     = options, \
 +		.version    = LIBAVUTIL_VERSION_INT, \
 +	};
 +

--- a/ffmpeg_patches/ffmpeg4.4_nvmpi.patch
+++ b/ffmpeg_patches/ffmpeg4.4_nvmpi.patch
@@ -187,10 +187,10 @@ index 2e9a358..f75ebca 100644
  extern AVCodec ff_vp9_vaapi_encoder;
 diff --git a/libavcodec/nvmpi_dec.c b/libavcodec/nvmpi_dec.c
 new file mode 100644
-index 0000000..4a77281
+index 0000000..166da0f
 --- /dev/null
 +++ b/libavcodec/nvmpi_dec.c
-@@ -0,0 +1,214 @@
+@@ -0,0 +1,221 @@
 +#include <stdio.h>
 +#include <stdlib.h>
 +#include <sys/time.h>
@@ -263,6 +263,13 @@ index 0000000..4a77281
 +        return AVERROR(EINVAL);
 +    }
 +	
++	//overwrite avctx w and h if resize option is used
++	if(resized.width && resized.height)
++	{
++		avctx->width = resized.width;
++		avctx->height = resized.height;
++	}
++
 +	nvmpi_context->bufFrame = av_frame_alloc();
 +	if (ff_get_buffer(avctx, nvmpi_context->bufFrame, 0) < 0) {
 +		av_frame_free(&(nvmpi_context->bufFrame));

--- a/ffmpeg_patches/ffmpeg6.0_nvmpi.patch
+++ b/ffmpeg_patches/ffmpeg6.0_nvmpi.patch
@@ -188,10 +188,10 @@ index e593ad1..954ed1b 100644
  extern const FFCodec ff_vp9_vaapi_encoder;
 diff --git a/libavcodec/nvmpi_dec.c b/libavcodec/nvmpi_dec.c
 new file mode 100644
-index 0000000..25cea51
+index 0000000..4a77281
 --- /dev/null
 +++ b/libavcodec/nvmpi_dec.c
-@@ -0,0 +1,198 @@
+@@ -0,0 +1,214 @@
 +#include <stdio.h>
 +#include <stdlib.h>
 +#include <sys/time.h>
@@ -207,6 +207,7 @@ index 0000000..25cea51
 +#include "libavutil/hwcontext_drm.h"
 +#include "libavutil/imgutils.h"
 +#include "libavutil/log.h"
++#include "libavutil/opt.h"
 +
 +#if LIBAVCODEC_VERSION_MAJOR >= 60
 +#include "codec_internal.h"
@@ -218,6 +219,7 @@ index 0000000..25cea51
 +	nvmpictx* ctx;
 +	AVClass *av_class;
 +	AVFrame *bufFrame;
++	char *resize_expr;
 +} nvmpiDecodeContext;
 +
 +static nvCodingType nvmpi_get_codingtype(AVCodecContext *avctx)
@@ -238,6 +240,7 @@ index 0000000..25cea51
 +
 +	nvmpiDecodeContext *nvmpi_context = avctx->priv_data;
 +	nvCodingType codectype=NV_VIDEO_CodingUnused;
++	nvSize resized = {0};
 +	
 +	codectype =nvmpi_get_codingtype(avctx);
 +	if (codectype == NV_VIDEO_CodingUnused) {
@@ -254,6 +257,12 @@ index 0000000..25cea51
 +		av_log(avctx, AV_LOG_ERROR, "Invalid Pix_FMT for NVMPI: Only YUV420P and YUVJ420P are supported\n");
 +		return AVERROR_INVALIDDATA;
 +	}
++
++    if (nvmpi_context->resize_expr && sscanf(nvmpi_context->resize_expr, "%dx%d",
++                                             &resized.width, &resized.height) != 2) {
++        av_log(avctx, AV_LOG_ERROR, "Invalid resize expressions\n");
++        return AVERROR(EINVAL);
++    }
 +	
 +	nvmpi_context->bufFrame = av_frame_alloc();
 +	if (ff_get_buffer(avctx, nvmpi_context->bufFrame, 0) < 0) {
@@ -262,7 +271,7 @@ index 0000000..25cea51
 +		return AVERROR(ENOMEM);
 +	}
 +
-+	nvmpi_context->ctx=nvmpi_create_decoder(codectype,NV_PIX_YUV420);
++	nvmpi_context->ctx=nvmpi_create_decoder(codectype, NV_PIX_YUV420, resized);
 +
 +	if(!nvmpi_context->ctx){
 +		av_frame_free(&(nvmpi_context->bufFrame));
@@ -337,10 +346,17 @@ index 0000000..25cea51
 +
 +
 +
++#define OFFSET(x) offsetof(nvmpiDecodeContext, x)
++#define VD AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_DECODING_PARAM
++static const AVOption options[] = {
++    { "resize",   "Resize (width)x(height)", OFFSET(resize_expr), AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, VD },
++    { NULL }
++};
 +
 +#define NVMPI_DEC_CLASS(NAME) \
 +	static const AVClass nvmpi_##NAME##_dec_class = { \
 +		.class_name = "nvmpi_" #NAME "_dec", \
++		.option     = options, \
 +		.version    = LIBAVUTIL_VERSION_INT, \
 +	};
 +

--- a/ffmpeg_patches/ffmpeg6.0_nvmpi.patch
+++ b/ffmpeg_patches/ffmpeg6.0_nvmpi.patch
@@ -188,10 +188,10 @@ index e593ad1..954ed1b 100644
  extern const FFCodec ff_vp9_vaapi_encoder;
 diff --git a/libavcodec/nvmpi_dec.c b/libavcodec/nvmpi_dec.c
 new file mode 100644
-index 0000000..4a77281
+index 0000000..166da0f
 --- /dev/null
 +++ b/libavcodec/nvmpi_dec.c
-@@ -0,0 +1,214 @@
+@@ -0,0 +1,221 @@
 +#include <stdio.h>
 +#include <stdlib.h>
 +#include <sys/time.h>
@@ -264,6 +264,13 @@ index 0000000..4a77281
 +        return AVERROR(EINVAL);
 +    }
 +	
++	//overwrite avctx w and h if resize option is used
++	if(resized.width && resized.height)
++	{
++		avctx->width = resized.width;
++		avctx->height = resized.height;
++	}
++
 +	nvmpi_context->bufFrame = av_frame_alloc();
 +	if (ff_get_buffer(avctx, nvmpi_context->bufFrame, 0) < 0) {
 +		av_frame_free(&(nvmpi_context->bufFrame));

--- a/include/nvmpi.h
+++ b/include/nvmpi.h
@@ -57,6 +57,10 @@ typedef struct _NVFRAME{
 	time_t timestamp;
 }nvFrame;
 
+typedef struct _NVSIZE{
+	unsigned int width;
+	unsigned int height;
+}nvSize;
 
 
 typedef enum {
@@ -73,7 +77,7 @@ typedef enum {
 extern "C" {
 #endif
 
-	nvmpictx* nvmpi_create_decoder(nvCodingType codingType,nvPixFormat pixFormat);
+	nvmpictx* nvmpi_create_decoder(nvCodingType codingType,nvPixFormat pixFormat, nvSize resized);
 
 	int nvmpi_decoder_put_packet(nvmpictx* ctx,nvPacket* packet);
 

--- a/src/nvmpi_dec.cpp
+++ b/src/nvmpi_dec.cpp
@@ -292,8 +292,8 @@ void nvmpictx::initFramePool()
 	NvBufferCreateParams input_params;
 	memset(&input_params, 0, sizeof(input_params));
 	/* Create PitchLinear output buffer for transform. */
-	input_params.width = output_width;
-	input_params.height = output_height;
+	input_params.width = coded_width;
+	input_params.height = coded_height;
 	input_params.layout = NvBufferLayout_Pitch;
 	input_params.colorFormat = cFmt;
 #ifdef WITH_NVUTILS
@@ -505,6 +505,7 @@ void dec_capture_loop_fcn(void *arg)
 	return;
 }
 
+//TODO: accept in nvmpi_create_decoder input stream params (width and height, etc...) from ffmpeg.
 nvmpictx* nvmpi_create_decoder(nvCodingType codingType, nvPixFormat pixFormat, nvSize resized){
 	
 	int ret;


### PR DESCRIPTION
This mirrors the `-resize` option that the cuvid decoders support. The resize operation happens for free while converting from BlockLinear to PitchLinear.