### PR TITLE
name decoder capture thread for easier debugging

### DIFF
--- a/src/nvmpi_dec.cpp
+++ b/src/nvmpi_dec.cpp
@@ -607,6 +607,7 @@ nvmpictx* nvmpi_create_decoder(nvDecParam* param)
 		ctx->dmaBufferFileDescriptor[index]=0;
 	ctx->numberCaptureBuffers=0;
 	ctx->dec_capture_loop = std::thread(dec_capture_loop_fcn,ctx);
+	pthread_setname_np(ctx->dec_capture_loop.native_handle(), "dec_capture");
 
 	return ctx;
 }


### PR DESCRIPTION
## Summary

Sets the pthread name "dec_capture" on the decoder capture loop thread via `pthread_setname_np`, making it identifiable in debuggers, `htop`, `top -H`, and `/proc/[pid]/task/[tid]/comm`.

### Changes

- `nvmpi_dec.cpp`: add `pthread_setname_np(ctx->dec_capture_loop.native_handle(), "dec_capture")` after thread creation in `nvmpi_create_decoder`

### Context

Split out from #15 which bundled this change with the unrelated stdout→stderr fix.

### Test plan

- [x] Create a decoder instance and verify the thread name appears as `dec_capture` in thread listings (`ps -T` or `/proc/[pid]/task/*/comm`)