### PR TITLE
fix stderr output

### DIFF
--- a/src/NVMPI_frameBuf.cpp
+++ b/src/NVMPI_frameBuf.cpp
@@ -8,14 +8,14 @@ bool NVMPI_frameBuf::alloc(NvBufferCreateParams& input_params)
 	ret = NvBufSurf::NvAllocate(&input_params, 1, &dst_dma_fd);
 	if(ret<0)
 	{
-		std::cout << "Failed to allocate buffer" << std::endl;
+		std::cerr << "Failed to allocate buffer" << std::endl;
 		return false;
 	}
 	
 	ret = NvBufSurfaceFromFd(dst_dma_fd, (void**)(&dst_dma_surface));
 	if(ret<0)
 	{
-		std::cout << "Failed to get surface for buffer" << std::endl;
+		std::cerr << "Failed to get surface for buffer" << std::endl;
 		NvBufferDestroy(dst_dma_fd);
 		dst_dma_fd = -1;
 		return false;
@@ -24,7 +24,7 @@ bool NVMPI_frameBuf::alloc(NvBufferCreateParams& input_params)
 	ret = NvBufferCreateEx(&dst_dma_fd, &input_params);
 	if(ret<0)
 	{
-		std::cout << "Failed to allocate buffer" << std::endl;
+		std::cerr << "Failed to allocate buffer" << std::endl;
 		return false;
 	}
 #endif
@@ -40,7 +40,7 @@ bool NVMPI_frameBuf::destroy()
 		ret = NvBufferDestroy(dst_dma_fd);
 		if(ret<0)
 		{
-			std::cout << "Failed to Destroy NvBuffer" << std::endl;
+			std::cerr << "Failed to Destroy NvBuffer" << std::endl;
 			return false;
 		}
 		dst_dma_fd = -1;

--- a/src/nvmpi_dec.cpp
+++ b/src/nvmpi_dec.cpp
@@ -634,7 +634,7 @@ int nvmpi_decoder_put_packet(nvmpictx* ctx,nvPacket* packet)
 		ret = ctx->dec->output_plane.dqBuffer(v4l2_buf, &nvBuffer, NULL, -1);
 		if (ret < 0)
 		{
-			cout << "Error DQing buffer at output plane" << std::endl;
+			cerr << "Error DQing buffer at output plane" << std::endl;
 			return -1;
 		}
 	}
@@ -686,7 +686,7 @@ int copyNvBufToFrame(nvmpictx* ctx, NVMPI_frameBuf *nvmpiBuf, nvFrame* frame)
 #endif
 		if(ret != 0)
 		{
-			printf("NvBufferMap failed \n");
+			fprintf(stderr, "NvBufferMap failed \n");
 			return ret;
 		}
 		

--- a/src/nvmpi_dec.cpp
+++ b/src/nvmpi_dec.cpp
@@ -17,7 +17,7 @@
 #define TEST_ERROR(condition, message, errorCode)    \
 	if (condition)                               \
 {                                                    \
-	std::cout<< message;			     \
+	std::cerr<< message;			     \
 }
 
 using namespace std;
@@ -650,7 +650,7 @@ int nvmpi_decoder_put_packet(nvmpictx* ctx,nvPacket* packet)
 	ret = ctx->dec->output_plane.qBuffer(v4l2_buf, NULL);
 	if (ret < 0)
 	{
-		std::cout << "Error Qing buffer at output plane" << std::endl;
+		std::cerr << "Error Qing buffer at output plane" << std::endl;
 		ctx->index--;
 		return -2;
 	}

--- a/src/nvmpi_enc.cpp
+++ b/src/nvmpi_enc.cpp
@@ -13,7 +13,7 @@
 #define TEST_ERROR(condition, message, errorCode)    \
 	if (condition)                               \
 {                                                    \
-	std::cout<< message;                         \
+	std::cerr<< message;                         \
 }
 
 #define OUTPLANE_MEMTYPE_MMAP 0

--- a/src/nvmpi_enc.cpp
+++ b/src/nvmpi_enc.cpp
@@ -67,7 +67,7 @@ static bool encoder_capture_plane_dq_callback(struct v4l2_buffer *v4l2_buf, NvBu
 
 	if (v4l2_buf == NULL)
 	{
-		cout << "Error while dequeing buffer from output plane" << endl;
+		cerr << "Error while dequeing buffer from output plane" << endl;
 		return false;
 	}
 
@@ -88,7 +88,7 @@ static bool encoder_capture_plane_dq_callback(struct v4l2_buffer *v4l2_buf, NvBu
 	{
 		//TODO wait for user to read buffer. make send_frame return AVERROR(EAGAIN) until avcodec_receive_packet() is called
 		//TODO pass warning to avlog
-		printf("[libnvmpi][W]: EAGAIN. User must read output. nvmpi encoder packet memory pool is empty! Packet will be dropped. There may be artifacts in the output video.\n");
+		fprintf(stderr, "[libnvmpi][W]: EAGAIN. User must read output. nvmpi encoder packet memory pool is empty! Packet will be dropped. There may be artifacts in the output video.\n");
 	}
 	else
 	{
@@ -572,7 +572,7 @@ int nvmpi_encoder_put_frame(nvmpictx* ctx,nvFrame* frame)
 		ret = ctx->enc->output_plane.dqBuffer(v4l2_buf, &nvBuffer, NULL, -1);
 		if (ret < 0)
 		{
-			cout << "Error DQing buffer at output plane" << std::endl;
+			cerr << "Error DQing buffer at output plane" << std::endl;
 			return false;
 		}
 	}


### PR DESCRIPTION
## Summary

ffmpeg pipes video output to downstream processes via stdout. Any diagnostic or error messages written to stdout corrupt the piped stream. This PR redirects all remaining stdout messages to stderr.

### Changes

- `TEST_ERROR` macro in `nvmpi_dec.cpp` and `nvmpi_enc.cpp`: `std::cout` → `std::cerr`
- `NVMPI_frameBuf.cpp`: all 4 `std::cout` error messages → `std::cerr`
- `nvmpi_dec.cpp`: `cout "Error DQing buffer"` → `cerr`, `printf "NvBufferMap failed"` → `fprintf(stderr, ...)`
- `nvmpi_dec.cpp`: `std::cout "Error Qing buffer"` → `std::cerr`
- `nvmpi_enc.cpp`: `cout "Error while dequeing"` → `cerr`, `cout "Error DQing buffer"` → `cerr`
- `nvmpi_enc.cpp`: `printf` EAGAIN warning → `fprintf(stderr, ...)`

### Context

Extends the scope of #15 which covered some but not all stdout messages. This PR covers every active `cout`/`printf` call across all three source files. The only remaining `cout` is inside a `/* */` comment block (dead code).

### Test plan

- [ ] Pipe ffmpeg output through nvmpi decoder/encoder to a downstream process and verify no diagnostic text appears in the video stream
- [ ] Trigger error conditions and verify messages appear on stderr