### PR TITLE
Add issue templates for GitHub and GitLab

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,112 @@
+name: Bug Report
+description: Report a bug with nvmpi encoding, decoding, or runtime behavior
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug. Please fill out the information below to help us reproduce and fix the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Clear description of the bug
+      placeholder: What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the issue
+      placeholder: |
+        1. Build with...
+        2. Run command...
+        3. Observe...
+    validations:
+      required: true
+
+  - type: textarea
+    id: ffmpeg-command
+    attributes:
+      label: FFmpeg command
+      description: The exact ffmpeg command that triggers the issue (if applicable)
+      render: bash
+
+  - type: textarea
+    id: error-output
+    attributes:
+      label: Error output
+      description: Relevant error messages, logs, or stack traces
+      render: text
+
+  - type: input
+    id: jetson-model
+    attributes:
+      label: Jetson model
+      placeholder: "e.g. Orin NX 16GB, AGX Orin 64GB, Orin Nano 8GB"
+    validations:
+      required: true
+
+  - type: input
+    id: jetpack-version
+    attributes:
+      label: JetPack / L4T version
+      placeholder: "e.g. JetPack 6.1 / L4T r36.4.0"
+    validations:
+      required: true
+
+  - type: input
+    id: ffmpeg-version
+    attributes:
+      label: FFmpeg version
+      description: Output of `ffmpeg -version` (first line)
+      placeholder: "e.g. ffmpeg version 7.1"
+    validations:
+      required: true
+
+  - type: input
+    id: nvmpi-version
+    attributes:
+      label: jetson-ffmpeg commit or version
+      description: Git commit hash or tag of jetson-ffmpeg used
+      placeholder: "e.g. 64df5aa or v1.0.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: build-method
+    attributes:
+      label: Build method
+      options:
+        - ffpatch.sh (patched ffmpeg source)
+        - CMake (nvmpi library only)
+        - Docker / container
+        - Pre-built package
+    validations:
+      required: true
+
+  - type: dropdown
+    id: codec
+    attributes:
+      label: Affected codec(s)
+      multiple: true
+      options:
+        - h264_nvmpi (encoder)
+        - h264_nvmpi (decoder)
+        - hevc_nvmpi (encoder)
+        - hevc_nvmpi (decoder)
+        - mpeg2_nvmpi (decoder)
+        - mpeg4_nvmpi (decoder)
+        - vp8_nvmpi (decoder)
+        - vp9_nvmpi (decoder)
+        - Not codec-specific
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other relevant information (workarounds tried, related issues, etc.)

--- a/.github/ISSUE_TEMPLATE/build-issue.yml
+++ b/.github/ISSUE_TEMPLATE/build-issue.yml
@@ -1,0 +1,98 @@
+name: Build Issue
+description: Report a compilation or build failure
+title: "[Build] "
+labels: ["build"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Report issues with building the nvmpi library or patching/compiling ffmpeg.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What are you trying to build and what fails?
+    validations:
+      required: true
+
+  - type: textarea
+    id: build-commands
+    attributes:
+      label: Build commands
+      description: The exact commands you ran
+      render: bash
+    validations:
+      required: true
+
+  - type: textarea
+    id: error-output
+    attributes:
+      label: Error output
+      description: Full build error output (compiler errors, cmake errors, configure errors)
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: jetson-model
+    attributes:
+      label: Jetson model
+      placeholder: "e.g. Orin NX 16GB, AGX Orin 64GB, Orin Nano 8GB"
+    validations:
+      required: true
+
+  - type: input
+    id: jetpack-version
+    attributes:
+      label: JetPack / L4T version
+      placeholder: "e.g. JetPack 6.1 / L4T r36.4.0"
+    validations:
+      required: true
+
+  - type: input
+    id: ffmpeg-version
+    attributes:
+      label: FFmpeg version / branch
+      placeholder: "e.g. release/7.1, release/6.0, n7.1"
+    validations:
+      required: true
+
+  - type: input
+    id: nvmpi-version
+    attributes:
+      label: jetson-ffmpeg commit or version
+      placeholder: "e.g. 64df5aa or v1.0.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: build-target
+    attributes:
+      label: Build target
+      options:
+        - nvmpi library (CMake)
+        - ffpatch.sh (patching)
+        - ffmpeg configure
+        - ffmpeg compilation
+        - ffmpeg linking
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Build environment
+      options:
+        - Native on Jetson
+        - Docker container (l4t-jetpack)
+        - Docker container (other)
+        - Cross-compilation
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: CMake flags used, environment details, patches applied, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Upstream (Keylost/jetson-ffmpeg)
+    url: https://github.com/Keylost/jetson-ffmpeg/issues
+    about: Issues specific to the upstream project

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,49 @@
+name: Feature Request
+description: Request a new feature or improvement
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Suggest a new feature, codec support, or improvement to jetson-ffmpeg.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What feature or improvement would you like?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: Why do you need this? What problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: If you have an idea for how to implement this, describe it here
+
+  - type: input
+    id: jetson-model
+    attributes:
+      label: Jetson model (if relevant)
+      placeholder: "e.g. Orin NX 16GB, AGX Orin 64GB"
+
+  - type: input
+    id: jetpack-version
+    attributes:
+      label: JetPack / L4T version (if relevant)
+      placeholder: "e.g. JetPack 6.1 / L4T r36.4.0"
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Related issues, links to NVIDIA documentation, example code, etc.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,46 @@
+name: Question
+description: Ask a question about usage, compatibility, or configuration
+title: "[Question] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Ask a question about jetson-ffmpeg usage, compatibility, or configuration.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: What have you tried?
+      description: Any steps, documentation, or solutions you have already looked at
+
+  - type: input
+    id: jetson-model
+    attributes:
+      label: Jetson model
+      placeholder: "e.g. Orin NX 16GB, AGX Orin 64GB, Orin Nano 8GB"
+
+  - type: input
+    id: jetpack-version
+    attributes:
+      label: JetPack / L4T version
+      placeholder: "e.g. JetPack 6.1 / L4T r36.4.0"
+
+  - type: input
+    id: ffmpeg-version
+    attributes:
+      label: FFmpeg version
+      placeholder: "e.g. ffmpeg version 7.1"
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context

--- a/.gitlab/issue_templates/Bug Report.md
+++ b/.gitlab/issue_templates/Bug Report.md
@@ -1,0 +1,49 @@
+## Bug Report
+
+### Description
+
+<!-- Clear description of the bug. What happened? What did you expect? -->
+
+### Steps to reproduce
+
+1. 
+2. 
+3. 
+
+### FFmpeg command
+
+```bash
+<!-- The exact ffmpeg command that triggers the issue (if applicable) -->
+```
+
+### Error output
+
+```
+<!-- Relevant error messages, logs, or stack traces -->
+```
+
+### Environment
+
+- **Jetson model**: <!-- e.g. Orin NX 16GB, AGX Orin 64GB, Orin Nano 8GB -->
+- **JetPack / L4T version**: <!-- e.g. JetPack 6.1 / L4T r36.4.0 -->
+- **FFmpeg version**: <!-- output of ffmpeg -version (first line) -->
+- **jetson-ffmpeg commit**: <!-- git commit hash or tag -->
+- **Build method**: <!-- ffpatch.sh / CMake / Docker / pre-built -->
+
+### Affected codec(s)
+
+- [ ] h264_nvmpi (encoder)
+- [ ] h264_nvmpi (decoder)
+- [ ] hevc_nvmpi (encoder)
+- [ ] hevc_nvmpi (decoder)
+- [ ] mpeg2_nvmpi (decoder)
+- [ ] mpeg4_nvmpi (decoder)
+- [ ] vp8_nvmpi (decoder)
+- [ ] vp9_nvmpi (decoder)
+- [ ] Not codec-specific
+
+### Additional context
+
+<!-- Any other relevant information, workarounds tried, related issues -->
+
+/label ~bug

--- a/.gitlab/issue_templates/Build Issue.md
+++ b/.gitlab/issue_templates/Build Issue.md
@@ -1,0 +1,32 @@
+## Build Issue
+
+### Description
+
+<!-- What are you trying to build and what fails? -->
+
+### Build commands
+
+```bash
+<!-- The exact commands you ran -->
+```
+
+### Error output
+
+```
+<!-- Full build error output -->
+```
+
+### Environment
+
+- **Jetson model**: <!-- e.g. Orin NX 16GB, AGX Orin 64GB -->
+- **JetPack / L4T version**: <!-- e.g. JetPack 6.1 / L4T r36.4.0 -->
+- **FFmpeg version / branch**: <!-- e.g. release/7.1, release/6.0 -->
+- **jetson-ffmpeg commit**: <!-- git commit hash or tag -->
+- **Build target**: <!-- nvmpi library (CMake) / ffpatch.sh / ffmpeg configure / ffmpeg compilation -->
+- **Build environment**: <!-- native on Jetson / Docker l4t-jetpack / Docker other / cross-compile -->
+
+### Additional context
+
+<!-- CMake flags, environment details, patches applied -->
+
+/label ~build

--- a/.gitlab/issue_templates/Feature Request.md
+++ b/.gitlab/issue_templates/Feature Request.md
@@ -1,0 +1,24 @@
+## Feature Request
+
+### Description
+
+<!-- What feature or improvement would you like? -->
+
+### Use case
+
+<!-- Why do you need this? What problem does it solve? -->
+
+### Proposed solution
+
+<!-- If you have an idea for implementation, describe it here -->
+
+### Environment (if relevant)
+
+- **Jetson model**: <!-- e.g. Orin NX 16GB, AGX Orin 64GB -->
+- **JetPack / L4T version**: <!-- e.g. JetPack 6.1 / L4T r36.4.0 -->
+
+### Additional context
+
+<!-- Related issues, links to NVIDIA docs, example code -->
+
+/label ~enhancement

--- a/.gitlab/issue_templates/GitHub Runner Token Request.md
+++ b/.gitlab/issue_templates/GitHub Runner Token Request.md
@@ -1,0 +1,34 @@
+## GitHub Runner Token Request
+
+**I would like to contribute a self-hosted Jetson runner to the GitHub Actions pipeline.**
+
+### Hardware
+
+- **Jetson model**: <!-- e.g. Orin NX, AGX Orin, Orin Nano, Xavier NX -->
+- **Proposed variant label**: <!-- e.g. orin-nx, agx, nano — used alongside the "jetson" label -->
+- **JetPack / L4T version**: <!-- e.g. JetPack 6.1 / L4T r36.4.0 -->
+
+### Runner environment
+
+- [ ] Kubernetes (k3s / k8s)
+- [ ] Bare-metal (directly on Jetson OS)
+
+### Checklist
+
+- [ ] NVIDIA Container Runtime / Docker with nvidia runtime is installed
+- [ ] I have verified GPU access (`nvidia-smi` or `tegrastats` works)
+- [ ] I have read the runner setup guide ([Kubernetes](docs/GITHUB_RUNNER_K8S.md) or [Manual](docs/GITHUB_RUNNER_MANUAL.md))
+
+### GitHub username
+
+<!-- Your GitHub username so the maintainer can grant runner access -->
+
+### Additional context
+
+<!-- Any relevant details: network constraints, availability schedule, etc. -->
+
+---
+
+**For maintainers:** after approving, add the requester's GitHub account to the repository runner group and share the registration token. The requester registers the runner with labels `self-hosted, jetson, <variant>`.
+
+/label ~runner-request

--- a/.gitlab/issue_templates/GitLab Runner Token Request.md
+++ b/.gitlab/issue_templates/GitLab Runner Token Request.md
@@ -1,0 +1,30 @@
+## GitLab Runner Token Request
+
+**I would like to contribute a Jetson runner to the GitLab CI pipeline.**
+
+### Hardware
+
+- **Jetson model**: <!-- e.g. Orin NX, AGX Orin, Orin Nano, Xavier NX -->
+- **Proposed variant tag**: <!-- e.g. orin-nx, agx, nano — used alongside the "jetson" tag -->
+- **JetPack / L4T version**: <!-- e.g. JetPack 6.1 / L4T r36.4.0 -->
+
+### Runner environment
+
+- [ ] Kubernetes (k3s / k8s)
+- [ ] Bare-metal (directly on Jetson OS)
+
+### Checklist
+
+- [ ] NVIDIA Container Runtime is installed and working
+- [ ] I have verified GPU access (`nvidia-smi` or `tegrastats` works)
+- [ ] I have read the runner setup guide ([Kubernetes](docs/GITLAB_RUNNER_K8S.md) or [Manual](docs/GITLAB_RUNNER_MANUAL.md))
+
+### Additional context
+
+<!-- Any relevant details: network constraints, availability schedule, etc. -->
+
+---
+
+**For maintainers:** after approving, create a project runner at **Settings > CI/CD > Runners > New project runner** with tags `jetson, <variant>` and share the `glrt-...` token with the requester via a secure channel.
+
+/label ~runner-request

--- a/.gitlab/issue_templates/Question.md
+++ b/.gitlab/issue_templates/Question.md
@@ -1,0 +1,19 @@
+## Question
+
+### Question
+
+<!-- What would you like to know? -->
+
+### What have you tried?
+
+<!-- Steps, documentation, or solutions you have already looked at -->
+
+### Environment (if relevant)
+
+- **Jetson model**: <!-- e.g. Orin NX 16GB, AGX Orin 64GB -->
+- **JetPack / L4T version**: <!-- e.g. JetPack 6.1 / L4T r36.4.0 -->
+- **FFmpeg version**: <!-- e.g. ffmpeg version 7.1 -->
+
+### Additional context
+
+/label ~question


### PR DESCRIPTION
### Summary
- GitHub issue templates (YAML forms): Bug Report, Build Issue, Feature Request, Question
- GitLab issue templates (markdown): Bug Report, Build Issue, Feature Request, Question
- GitLab Runner Token Request (for requesting GitLab CI runner access)
- GitHub Runner Token Request (for requesting GitHub Actions runner access)
- `config.yml` disabling blank issues with link to upstream (Keylost/jetson-ffmpeg)

All templates collect Jetson model, JetPack/L4T version, FFmpeg version, and
codec selection where applicable. Based on common issue patterns from upstream.

### Test plan
- [x] Verify GitHub templates render correctly at `/issues/new/choose`
- [x] Verify GitLab templates appear in issue dropdown
- [ ] Confirm blank issues are disabled on GitHub
- [ ] Confirm upstream link renders in GitHub issue chooser

> **Note:** `feat/gitlab` and `feat/github` depend on this branch — merge this first.